### PR TITLE
remove HTML from package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-s3-uploader",
   "version": "1.1.1",
-  "description": "React component that renders an <input type=\"file\"/> and automatically uploads to an S3 bucket",
+  "description": "React component that renders a file input and automatically uploads to an S3 bucket",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
The npm website now allows and renders some HTML tags in package descriptions, like `<strong>` and `<a>`. The full list is here: https://www.npmjs.com/package/sanitize-html#how-to-use

`<input>` is not on the whitelist though, so it'll get stripped out. This change works around that. by using a plain English description.