### PR TITLE
Fix mime-type detection by properly replacing whitespace in filenames

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -59,7 +59,7 @@ S3Upload.prototype.createCORSRequest = function(method, url) {
 
 S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
     var xhr = new XMLHttpRequest();
-    var fileName = file.name.replace(/\ /g, "_");
+    var fileName = file.name.replace(/\s+/g, "_");
     xhr.open('GET', this.signingUrl + '?objectName=' + fileName, true);
     xhr.overrideMimeType && xhr.overrideMimeType('text/plain; charset=x-user-defined');
     xhr.onreadystatechange = function() {

--- a/s3upload.js
+++ b/s3upload.js
@@ -59,7 +59,7 @@ S3Upload.prototype.createCORSRequest = function(method, url) {
 
 S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
     var xhr = new XMLHttpRequest();
-    var fileName = file.name.replace(/[^\w]/g, "_");
+    var fileName = file.name.replace(/\ /g, "_");
     xhr.open('GET', this.signingUrl + '?objectName=' + fileName, true);
     xhr.overrideMimeType && xhr.overrideMimeType('text/plain; charset=x-user-defined');
     xhr.onreadystatechange = function() {


### PR DESCRIPTION
The regular expression used to replace whitespace in filenames is incorrect; \w ends up replacing "." with "_". This change fixes mime-type detection.