### PR TITLE
Add option for ACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Server-Side
 You can use the Express router that is bundled with this module to answer calls to `/s3/sign`
 
     app.use('/s3', require('react-s3-uploader/s3router')({
-        bucket: "MyS3Bucket"
+        bucket: "MyS3Bucket",
+        ACL: 'private' // this is default
     }));
 
 This also provides another endpoint: `GET /s3/img/(.*)`.  This will create a temporary URL

--- a/s3router.js
+++ b/s3router.js
@@ -15,7 +15,6 @@ function checkTrailingSlash(path) {
 function S3Router(options) {
 
     var S3_BUCKET = options.bucket,
-        ACL = options.ACL,
         getFileKeyDir = options.getFileKeyDir || function() { return ""; };
 
     if (!S3_BUCKET) {
@@ -54,7 +53,7 @@ function S3Router(options) {
             Key: fileKey,
             Expires: 60,
             ContentType: mimeType,
-            ACL: options.ACL ? options.ACL : 'private'
+            ACL: options.ACL || 'private'
         };
         s3.getSignedUrl('putObject', params, function(err, data) {
             if (err) {

--- a/s3router.js
+++ b/s3router.js
@@ -15,6 +15,7 @@ function checkTrailingSlash(path) {
 function S3Router(options) {
 
     var S3_BUCKET = options.bucket,
+        ACL = options.ACL,
         getFileKeyDir = options.getFileKeyDir || function() { return ""; };
 
     if (!S3_BUCKET) {
@@ -53,7 +54,7 @@ function S3Router(options) {
             Key: fileKey,
             Expires: 60,
             ContentType: mimeType,
-            ACL: 'private'
+            ACL: options.ACL ? options.ACL : 'private'
         };
         s3.getSignedUrl('putObject', params, function(err, data) {
             if (err) {


### PR DESCRIPTION
This gives the ability to pass other ACL parameters i.e. `public-read`, while still being backwards compatible and falling back to `private` if no option is present. 