### PR TITLE
Add option to optionally set Content-Disposition: header

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,18 @@ From Browser
         onFinish={this.onUploadFinish}
         signingUrlHeaders={{ additional: headers }}
         signingUrlQueryParams={{ additional: query-params }}
-        uploadRequestHeaders={{ 'x-amz-acl', 'public-read' }} />
+        uploadRequestHeaders={{ 'x-amz-acl', 'public-read' }}
+        contentDisposition="auto" />
 
 The above example shows all supported `props`.  For `uploadRequestHeaders`, the default ACL is shown.
 
 This expects a request to `/s3/sign` to return JSON with a `signedUrl` property that can be used
 to PUT the file in S3.
+
+`contentDisposition` is optional and can be one of `inline`, `attachment` or `auto`. If given,
+the `Content-Disposition` header will be set accordingly with the file's original filename.
+If it is `auto`, the disposition type will be set to `inline` for images and `attachment` for
+all other files.
 
 The resulting DOM is essentially:
 

--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -13,7 +13,8 @@ var ReactS3Uploader = React.createClass({
         onError: React.PropTypes.func,
         signingUrlHeaders: React.PropTypes.object,
         signingUrlQueryParams: React.PropTypes.object,
-        uploadRequestHeaders: React.PropTypes.object
+        uploadRequestHeaders: React.PropTypes.object,
+        contentDisposition: React.PropTypes.string
     },
 
     getDefaultProps: function() {
@@ -39,7 +40,8 @@ var ReactS3Uploader = React.createClass({
             onError: this.props.onError,
             signingUrlHeaders: this.props.signingUrlHeaders,
             signingUrlQueryParams: this.props.signingUrlQueryParams,
-            uploadRequestHeaders: this.props.uploadRequestHeaders
+            uploadRequestHeaders: this.props.uploadRequestHeaders,
+            contentDisposition: this.props.contentDisposition
         });
     },
 

--- a/s3upload.js
+++ b/s3upload.js
@@ -122,11 +122,11 @@ S3Upload.prototype.uploadToS3 = function(file, signResult) {
     if (this.contentDisposition) {
         var disposition = this.contentDisposition;
         if (disposition === 'auto') {
-          if (file.type.substr(0, 6) === 'image/') {
-            disposition = 'inline';
-          } else {
-            disposition = 'attachment';
-          }
+            if (file.type.substr(0, 6) === 'image/') {
+                disposition = 'inline';
+            } else {
+                disposition = 'attachment';
+            }
         }
         var fileName = file.name.replace(/\s+/g, "_");
         xhr.setRequestHeader('Content-Disposition', disposition + '; filename=' + fileName);

--- a/s3upload.js
+++ b/s3upload.js
@@ -119,6 +119,18 @@ S3Upload.prototype.uploadToS3 = function(file, signResult) {
         }.bind(this);
     }
     xhr.setRequestHeader('Content-Type', file.type);
+    if (this.contentDisposition) {
+        var disposition = this.contentDisposition;
+        if (disposition === 'auto') {
+          if (file.type.substr(0, 6) === 'image/') {
+            disposition = 'inline';
+          } else {
+            disposition = 'attachment';
+          }
+        }
+        var fileName = file.name.replace(/\s+/g, "_");
+        xhr.setRequestHeader('Content-Disposition', disposition + '; filename=' + fileName);
+    }
     if (this.uploadRequestHeaders) {
         var uploadRequestHeaders = this.uploadRequestHeaders;
         Object.keys(uploadRequestHeaders).forEach(function(key) {


### PR DESCRIPTION
This adds the ability to set the Content-Disposition: header with the uploaded file's original filename. This is useful to have UUIDs as keys in S3, yet the end user still sees a familiar-looking filename.