### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ From Browser
         onFinish={this.onUploadFinish}
         signingUrlHeaders={{ additional: headers }}
         signingUrlQueryParams={{ additional: query-params }}
-        uploadRequestHeaders={{ 'x-amz-acl', 'public-read' }}
+        uploadRequestHeaders={{ 'x-amz-acl': 'public-read' }}
         contentDisposition="auto" />
 
 The above example shows all supported `props`.  For `uploadRequestHeaders`, the default ACL is shown.


### PR DESCRIPTION
I assume this is a typo. Also I'd probably suggest for copy/pastability that it might be nice if the example included compilable parameters for `signingUrlHeaders` because some people just try and copy/paste stuff from readmes and give up when it doesn't work. Just a suggestion though... 

Thanks for this library! It slots in nicely to our react app.