### PR TITLE
url encode the contentType

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -64,7 +64,7 @@ S3Upload.prototype.createCORSRequest = function(method, url) {
 S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
     var normalizedFileName = unorm.nfc(file.name.replace(/\s+/g, "_"));
     var fileName = latinize(normalizedFileName);
-    var queryString = '?objectName=' + fileName + '&contentType=' + file.type;
+    var queryString = '?objectName=' + fileName + '&contentType=' + encodeURIComponent(file.type);
     if (this.signingUrlQueryParams) {
         var signingUrlQueryParams = this.signingUrlQueryParams;
         Object.keys(signingUrlQueryParams).forEach(function(key) {


### PR DESCRIPTION
Uploading SVG files caused issues as the mime type is `image/svg+xml` and I found that when using Hapi the '+' gets stripped out.