### PR TITLE
Remove express from the peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ This also provides another endpoint: `GET /s3/img/(.*)` and `GET /s3/uploads/(.*
 that provides access to the uploaded file (which are uploaded privately by default).  The
 request is then redirected to the URL, so that the image is served to the client.
 
+**To use this you will need to include the [express module](https://www.npmjs.com/package/express) in your package.json dependencies.**
+
 #### Access/Secret Keys
 
 The `aws-sdk` must be configured with your account's Access Key and Secret Access Key.  [There are a number of ways to provide these](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html), but setting up environment variables is the quickest.  You just have to configure environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, and AWS automatically picks them up.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "unorm": "1.4.x"
   },
   "peerDependencies": {
-    "express": "4.x",
     "react": "*"
   }
 }


### PR DESCRIPTION
but make it clear in the docs that it is required if you want to use the built in router