### PR TITLE
remove the 'public-read' acl as the default. 

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -143,8 +143,6 @@ S3Upload.prototype.uploadToS3 = function(file, signResult) {
             var val = uploadRequestHeaders[key];
             xhr.setRequestHeader(key, val);
         });
-    } else {
-        xhr.setRequestHeader('x-amz-acl', 'public-read');
     }
     this.httprequest = xhr;
     return xhr.send(file);


### PR DESCRIPTION
Prefer to use bucket policy permissions over acls.

I have some permissions set at at a bucket level and don't want my uploading application to be concerned about the permissions for a given file. That should be managed elsewhere.

This still leaves in place the ability to override permissions with a file level acl.
