### PR TITLE
Removed xhr.responseText from onError message

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -88,7 +88,7 @@ S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
             try {
                 result = JSON.parse(xhr.responseText);
             } catch (error) {
-                this.onError('Invalid signing server response JSON: ' + xhr.responseText, file);
+                this.onError('Invalid response from server', file);
                 return false;
             }
             return callback(result);


### PR DESCRIPTION
If the `xhr.responseText` is an HTML page it will fail at  `JSON.parse` and then be sent to the `onError` handler. This could result in a very large error message being rendered on the front end.