### PR TITLE
Failed to execute 'setrequestheader' on 'xmlhttprequest' is not a valid HTTP header field value

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -63,7 +63,7 @@ S3Upload.prototype.createCORSRequest = function(method, url) {
 };
 
 S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
-    var normalizedFileName = unorm.nfc(file.name.replace(/\s+/g, "_"));
+    var normalizedFileName = unorm.nfc(file.name.replace(/[^a-zA-Z0-9]/g, "_"));
     var fileName = latinize(normalizedFileName);
     var queryString = '?objectName=' + fileName + '&contentType=' + encodeURIComponent(file.type);
     if (this.signingUrlQueryParams) {

--- a/s3upload.js
+++ b/s3upload.js
@@ -134,7 +134,7 @@ S3Upload.prototype.uploadToS3 = function(file, signResult) {
                 disposition = 'attachment';
             }
         }
-        var normalizedFileName = unorm.nfc(file.name.replace(/\s+/g, "_"));
+        var normalizedFileName = unorm.nfc(file.name.replace(/[^a-zA-Z0-9]/g, "_"));
         var fileName = latinize(normalizedFileName);
         xhr.setRequestHeader('Content-Disposition', disposition + '; filename=' + fileName);
     }


### PR DESCRIPTION
Got this error:

> failed to execute 'setrequestheader' on 'xmlhttprequest' is not a valid http header field value

when trying to upload file with "'" caracter
e.g "Capture d’écran 2016-04-25 à 10.27.34.png"
