### PR TITLE
FIX: getInputProps fails at minify version

### DIFF
--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -59,7 +59,7 @@ var ReactS3Uploader = React.createClass({
         return React.DOM.input(this.getInputProps());
     },
 
-    getInputProps() {
+    getInputProps: function() {
         var temporaryProps = objectAssign({}, this.props, {type: 'file', onChange: this.uploadFile});
         var inputProps = {};
 


### PR DESCRIPTION
When using a minify (uglify) complains about ` getInputProps()` so i updated that line.