### PR TITLE
Remove console log

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -16,7 +16,6 @@ S3Upload.prototype.onFinishS3Put = function(signResult, file) {
 };
 
 S3Upload.prototype.preprocess = function(file, next) {
-    console.log('base.preprocess()', file);
     return next(file);
 };
 


### PR DESCRIPTION
We are returning the file, so there's no need to log it. It's displaying in a production environment, so would be nice to remove it.
