### PR TITLE
Quote Content-Disposition filename

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -143,7 +143,7 @@ S3Upload.prototype.uploadToS3 = function(file, signResult) {
         }
         var normalizedFileName = unorm.nfc(file.name.replace(/[!\^`><{}\[\]()*#%'"~|&@:;$=+?\s\\\/\x00-\x1F\x7f]+/ig, '_'));
         var fileName = latinize(normalizedFileName);
-        xhr.setRequestHeader('Content-Disposition', disposition + '; filename=' + fileName);
+        xhr.setRequestHeader('Content-Disposition', disposition + '; filename="' + fileName + '"');
     }
     if (this.uploadRequestHeaders) {
         var uploadRequestHeaders = this.uploadRequestHeaders;


### PR DESCRIPTION
Quoting the filename fixes https://github.com/odysseyscience/react-s3-uploader/issues/76

Also, the spec appears to suggest that the filename should be a quoted string: https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1

