### PR TITLE
Add ability to use any http verb and `xhr.withCredentials` option …

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ var ReactS3Uploader = require('react-s3-uploader');
 
 <ReactS3Uploader
     signingUrl="/s3/sign"
+    signingUrlMethod="POST"                 // default "GET"
     accept="image/*"
     preprocess={this.onUploadStart}
     onProgress={this.onUploadProgress}
@@ -25,6 +26,7 @@ var ReactS3Uploader = require('react-s3-uploader');
     onFinish={this.onUploadFinish}
     signingUrlHeaders={{ additional: headers }}
     signingUrlQueryParams={{ additional: query-params }}
+    signingUrlWithCredentials={ true }      // in case when need to pass authentication credentials via CORS
     uploadRequestHeaders={{ 'x-amz-acl': 'public-read' }}
     contentDisposition="auto"
     server="http://cross-origin-server.com" />
@@ -180,6 +182,11 @@ If you do some work on another server, and would love to contribute documentatio
 
 Changelog (Starting at 1.2.0)
 ------------
+
+##### 3.4.0
+
+* Adding optional prop `signingUrlMethod` (default: `GET`)
+* Adding optional prop `signingUrlWithCredentials`
 
 ##### 3.3.0
 * Adding optional preprocess hook supports asynchronous operations such as resizing an image before upload [#79 #72]

--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ Changelog (Starting at 1.2.0)
 
 ##### 3.4.0
 
-* Adding optional prop `signingUrlMethod` (default: `GET`)
-* Adding optional prop `signingUrlWithCredentials`
+* Adding optional prop `signingUrlMethod` (default: `GET`) [#103]
+* Adding optional prop `signingUrlWithCredentials` [#103]
 
 ##### 3.3.0
 * Adding optional preprocess hook supports asynchronous operations such as resizing an image before upload [#79 #72]

--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -14,11 +14,13 @@ var ReactS3Uploader = React.createClass({
         onProgress: React.PropTypes.func,
         onFinish: React.PropTypes.func,
         onError: React.PropTypes.func,
+        signingUrlMethod: React.PropTypes.string,
         signingUrlHeaders: React.PropTypes.object,
         signingUrlQueryParams: React.PropTypes.oneOfType([
           React.PropTypes.object,
           React.PropTypes.func
         ]),
+        signingUrlWithCredentials: React.PropTypes.bool,
         uploadRequestHeaders: React.PropTypes.object,
         contentDisposition: React.PropTypes.string,
         server: React.PropTypes.string
@@ -39,7 +41,8 @@ var ReactS3Uploader = React.createClass({
             onError: function(message) {
                 console.log("Upload error: " + message);
             },
-            server: ''
+            server: '',
+            signingUrlMethod: 'GET'
         };
     },
 
@@ -52,8 +55,10 @@ var ReactS3Uploader = React.createClass({
             onProgress: this.props.onProgress,
             onFinishS3Put: this.props.onFinish,
             onError: this.props.onError,
+            signingUrlMethod: this.props.signingUrlMethod,
             signingUrlHeaders: this.props.signingUrlHeaders,
             signingUrlQueryParams: this.props.signingUrlQueryParams,
+            signingUrlWithCredentials: this.props.signingUrlWithCredentials,
             uploadRequestHeaders: this.props.uploadRequestHeaders,
             contentDisposition: this.props.contentDisposition,
             server: this.props.server

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-s3-uploader",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "React component that renders a file input and automatically uploads to an S3 bucket",
   "main": "index.js",
   "scripts": {

--- a/s3upload.js
+++ b/s3upload.js
@@ -8,6 +8,7 @@ var latinize = require('latinize'),
 
 S3Upload.prototype.server = '';
 S3Upload.prototype.signingUrl = '/sign-s3';
+S3Upload.prototype.signingUrlMethod = 'GET';
 S3Upload.prototype.fileElement = null;
 S3Upload.prototype.files = null;
 
@@ -53,10 +54,12 @@ S3Upload.prototype.handleFileSelect = function(files) {
     }
 };
 
-S3Upload.prototype.createCORSRequest = function(method, url) {
+S3Upload.prototype.createCORSRequest = function(method, url, opts) {
+    var opts = opts || {};
     var xhr = new XMLHttpRequest();
 
     if (xhr.withCredentials != null) {
+        if (opts.withCredentials != null) xhr.withCredentials = opts.withCredentials;
         xhr.open(method, url, true);
     }
     else if (typeof XDomainRequest !== "undefined") {
@@ -80,8 +83,8 @@ S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
             queryString += '&' + key + '=' + val;
         });
     }
-    var xhr = this.createCORSRequest('GET',
-        this.server + this.signingUrl + queryString);
+    var xhr = this.createCORSRequest(this.signingUrlMethod,
+        this.server + this.signingUrl + queryString, { withCredentials: this.signingUrlWithCredentials });
     if (this.signingUrlHeaders) {
         var signingUrlHeaders = this.signingUrlHeaders;
         Object.keys(signingUrlHeaders).forEach(function(key) {


### PR DESCRIPTION
… for signingUrl request.

In my case I need `POST` because controller creating and persist upload entity and assign signed url with one. So calling `signingUrl` is not idempotent.

Also my API requires authentication. Cookies would not be passed via CORS without `xhr.withCredentials = true` .