### PR TITLE
#111 Add option to drop prefix from filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ app.use('/s3', require('react-s3-uploader/s3router')({
     signatureVersion: 'v4', //optional (use for some amazon regions: frankfurt and others)
     headers: {'Access-Control-Allow-Origin': '*'}, // optional
     ACL: 'private', // this is default
-    prefixFilename=true // this is default, setting the attribute to false preserves the original filename in S3
+    uniquePrefix=true // this is default, setting the attribute to false preserves the original filename in S3
 }));
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ app.use('/s3', require('react-s3-uploader/s3router')({
     region: 'us-east-1', //optional
     signatureVersion: 'v4', //optional (use for some amazon regions: frankfurt and others)
     headers: {'Access-Control-Allow-Origin': '*'}, // optional
-    ACL: 'private' // this is default
+    ACL: 'private', // this is default
+    prefixFilename=true // this is default, setting the attribute to false preserves the original filename in S3
 }));
 ```
 

--- a/s3router.js
+++ b/s3router.js
@@ -27,8 +27,8 @@ function S3Router(options) {
     if (options.signatureVersion) {
         s3Options.signatureVersion = options.signatureVersion;
     }
-    if (options.prefixName === undefined) {
-        options.prefixName = true;
+    if (options.uniquePrefix === undefined) {
+        options.uniquePrefix = true;
     }
 
     var router = express.Router();
@@ -67,7 +67,7 @@ function S3Router(options) {
      * give temporary access to PUT an object in an S3 bucket.
      */
     router.get('/sign', function(req, res) {
-        var filename = (options.prefixName ? uuid.v4() + "_" : "") + req.query.objectName;
+        var filename = (options.uniquePrefix ? uuid.v4() + "_" : "") + req.query.objectName;
         var mimeType = req.query.contentType;
         var fileKey = checkTrailingSlash(getFileKeyDir(req)) + filename;
         // Set any custom headers

--- a/s3router.js
+++ b/s3router.js
@@ -27,6 +27,9 @@ function S3Router(options) {
     if (options.signatureVersion) {
         s3Options.signatureVersion = options.signatureVersion;
     }
+    if (options.prefixName === undefined) {
+        options.prefixName = true;
+    }
 
     var router = express.Router();
 
@@ -64,7 +67,7 @@ function S3Router(options) {
      * give temporary access to PUT an object in an S3 bucket.
      */
     router.get('/sign', function(req, res) {
-        var filename = uuid.v4() + "_" + req.query.objectName;
+        var filename = (options.prefixName ? uuid.v4() + "_" : "") + req.query.objectName;
         var mimeType = req.query.contentType;
         var fileKey = checkTrailingSlash(getFileKeyDir(req)) + filename;
         // Set any custom headers


### PR DESCRIPTION
Setting `prefixName` to `false` when initializing the signing server endpoint preserves the original filename in S3.