### PR TITLE
Return filekey

### DIFF
--- a/s3router.js
+++ b/s3router.js
@@ -91,7 +91,8 @@ function S3Router(options) {
             res.json({
                 signedUrl: data,
                 publicUrl: '/s3/uploads/' + filename,
-                filename: filename
+                filename: filename,
+                fileKey: fileKey,
             });
         });
     });


### PR DESCRIPTION
Is there any reason why the `filekey` isn't returned in the response body?