### PR TITLE
Fix INVALID_STATE_ERR: DOM Exception 11

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -60,10 +60,10 @@ S3Upload.prototype.createCORSRequest = function(method, url, opts) {
     var xhr = new XMLHttpRequest();
 
     if (xhr.withCredentials != null) {
+        xhr.open(method, url, true);
         if (opts.withCredentials != null) {
             xhr.withCredentials = opts.withCredentials;
         }
-        xhr.open(method, url, true);
     }
     else if (typeof XDomainRequest !== "undefined") {
         xhr = new XDomainRequest();


### PR DESCRIPTION
Experienced INVALID_STATE_ERR: DOM Exception 11 while using Safari 5.1.7 on Windows 10 and signingUrlWithCredentials set to true