### PR TITLE
Adding abiltiy to pass function for signingUrlHeaders

### DIFF
--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -17,7 +17,10 @@ var ReactS3Uploader = createReactClass({
         onFinish: PropTypes.func,
         onError: PropTypes.func,
         signingUrlMethod: PropTypes.string,
-        signingUrlHeaders: PropTypes.object,
+        signingUrlHeaders: PropTypes.oneOfType([
+          PropTypes.object,
+          PropTypes.func
+        ]),
         signingUrlQueryParams: PropTypes.oneOfType([
           PropTypes.object,
           PropTypes.func

--- a/s3upload.js
+++ b/s3upload.js
@@ -88,7 +88,7 @@ S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
     var xhr = this.createCORSRequest(this.signingUrlMethod,
         this.server + this.signingUrl + queryString, { withCredentials: this.signingUrlWithCredentials });
     if (this.signingUrlHeaders) {
-        var signingUrlHeaders = this.signingUrlHeaders;
+        var signingUrlHeaders = typeof this.signingUrlHeaders === 'function' ? this.signingUrlHeaders() : this.signingUrlHeaders;
         Object.keys(signingUrlHeaders).forEach(function(key) {
             var val = signingUrlHeaders[key];
             xhr.setRequestHeader(key, val);


### PR DESCRIPTION
There are scenarios where it's useful to have a function for getting the url headers, for example when generating a short-lived authentication token.