### PR TITLE
Support setting headers in signResult callback

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -150,6 +150,13 @@ S3Upload.prototype.uploadToS3 = function(file, signResult) {
         var fileName = this.scrubFilename(file.name)
         xhr.setRequestHeader('Content-Disposition', disposition + '; filename="' + fileName + '"');
     }
+    if (signResult.headers) {
+        var signResultHeaders = signResult.headers
+        Object.keys(signResultHeaders).forEach(function(key) {
+            var val = signResultHeaders[key];
+            xhr.setRequestHeader(key, val);
+        })
+    }
     if (this.uploadRequestHeaders) {
         var uploadRequestHeaders = this.uploadRequestHeaders;
         Object.keys(uploadRequestHeaders).forEach(function(key) {


### PR DESCRIPTION
For users who rely on header authorization in signedUrls, this enables them to add such headers to the callback of a `getSignedUrl` function