### PR TITLE
Fixes #127: Use createElement instead of DOM.input

### DIFF
--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -81,7 +81,7 @@ var ReactS3Uploader = createReactClass({
     },
 
     render: function() {
-        return React.DOM.input(this.getInputProps());
+        return React.createElement('input', this.getInputProps());
     },
 
     getInputProps: function() {


### PR DESCRIPTION
DOM.input is deprecated and being dropped in React 16. Giving `createElement` a try locally looks to work as expected. 