### PR TITLE
Fixes #115: Use uuid instead of node-uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "dependencies": {
     "aws-sdk": "2.x",
     "create-react-class": "^15.5.2",
-    "node-uuid": "1.x",
     "object-assign": "^2.0.0",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "uuid": "^3.1.0"
   },
   "peerDependencies": {
     "react": "*",

--- a/s3router.js
+++ b/s3router.js
@@ -1,5 +1,4 @@
-
- var uuid = require('node-uuid'),
+ var uuidv4 = require('uuid/v4'),
      aws = require('aws-sdk'),
      express = require('express');
 
@@ -67,7 +66,7 @@ function S3Router(options) {
      * give temporary access to PUT an object in an S3 bucket.
      */
     router.get('/sign', function(req, res) {
-        var filename = (options.uniquePrefix ? uuid.v4() + "_" : "") + req.query.objectName;
+        var filename = (options.uniquePrefix ? uuidv4() + "_" : "") + req.query.objectName;
         var mimeType = req.query.contentType;
         var fileKey = checkTrailingSlash(getFileKeyDir(req)) + filename;
         // Set any custom headers


### PR DESCRIPTION
The `uuid` package is unsafe, `node-uuid` is virtually identical and is the replacement. So far as I can tell, it's a drop in replacement. Trying the default configuration manually, it appears to work as expected.