### PR TITLE
Update s3router.js

### DIFF
--- a/s3router.js
+++ b/s3router.js
@@ -16,7 +16,7 @@ function S3Router(options) {
         getFileKeyDir = options.getFileKeyDir || function() { return ""; };
 
     if (!S3_BUCKET) {
-        throw new Error("S3_BUCKET is required.");
+        new Error("S3_BUCKET is required.");
     }
 
     var s3Options = {};


### PR DESCRIPTION
throw new Error does not work with AWS Lambda/Express/Serverless and gives the bellow error in production. Do you think you can use new Error("S3_BUCKET is required."); please. Otherwise have to upload all node modules to production/ source code manually.

module initialization error: Error
at S3Router (/var/task/node_modules/react-s3-uploader/s3router.js:19:15)
at Object.<anonymous> (/var/task/app.js:196:16)
at Module._compile (module.js:570:32)
at Object.Module._extensions..js (module.js:579:10)
at Module.load (module.js:487:32)
at tryModuleLoad (module.js:446:12)
at Function.Module._load (module.js:438:3)
at Module.require (module.js:497:17)
at require (internal/module.js:20:19)
at Object.<anonymous> (/var/task/lambda.js:3:13)
at Module._compile (module.js:570:32)
at Object.Module._extensions..js (module.js:579:10)
at Module.load (module.js:487:32)
at tryModuleLoad (module.js:446:12)
at Function.Module._load (module.js:438:3)
at Module.require (module.js:497:17)