### PR TITLE
Add support to provide middle ware options to express router

### DIFF
--- a/s3router.js
+++ b/s3router.js
@@ -10,7 +10,11 @@ function checkTrailingSlash(path) {
     return path;
 }
 
-function S3Router(options) {
+function S3Router(options, middleware) {
+
+    if (!middleware) {
+        middleware = [];
+    }
 
     var S3_BUCKET = options.bucket,
         getFileKeyDir = options.getFileKeyDir || function() { return ""; };
@@ -50,14 +54,14 @@ function S3Router(options) {
     /**
      * Image specific route.
      */
-    router.get(/\/img\/(.*)/, function(req, res) {
+    router.get(/\/img\/(.*)/, middleware, function(req, res) {
         return tempRedirect(req, res);
     });
 
     /**
      * Other file type(s) route.
      */
-    router.get(/\/uploads\/(.*)/, function(req, res) {
+    router.get(/\/uploads\/(.*)/, middleware, function(req, res) {
         return tempRedirect(req, res);
     });
 
@@ -65,7 +69,7 @@ function S3Router(options) {
      * Returns an object with `signedUrl` and `publicUrl` properties that
      * give temporary access to PUT an object in an S3 bucket.
      */
-    router.get('/sign', function(req, res) {
+    router.get('/sign', middleware, function(req, res) {
         var filename = (options.uniquePrefix ? uuidv4() + "_" : "") + req.query.objectName;
         var mimeType = req.query.contentType;
         var fileKey = checkTrailingSlash(getFileKeyDir(req)) + filename;


### PR DESCRIPTION
It's quite common for developers to want to protect their routes (especially if those routes interact with server resources like s3 buckets) with middle ware.

I love the library, but while trying to use it in a project it was not feasible out of the box as I could not use auth protected routes, rate limiting etc.

This PR allows a user to provide middle ware options to be used by the express routes.

This is my first PR in this repo so apologies if I missed any styling guidelines.