### PR TITLE
Add Param getS3 to allow custom S3 configuration and mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ This also provides another endpoint: `GET /s3/img/(.*)` and `GET /s3/uploads/(.*
 that provides access to the uploaded file (which are uploaded privately by default).  The
 request is then redirected to the URL, so that the image is served to the client.
 
+If you need to use pass more than region and signatureVersion to S3 instead use the `getS3` param. `getS3` accepts a
+function that returns a new AWS.S3 instance. This is also useful if you want to mock S3 for testing purposes.
+
 **To use this you will need to include the [express module](https://www.npmjs.com/package/express) in your package.json dependencies.**
 
 #### Access/Secret Keys

--- a/s3router.js
+++ b/s3router.js
@@ -23,13 +23,21 @@ function S3Router(options, middleware) {
         throw new Error("S3_BUCKET is required.");
     }
 
-    var s3Options = {};
-    if (options.region) {
-      s3Options.region = options.region;
-    }
-    if (options.signatureVersion) {
+    var getS3 = options.getS3;
+    if (!getS3) {
+      var s3Options = {};
+      if (options.region) {
+        s3Options.region = options.region;
+      }
+      if (options.signatureVersion) {
         s3Options.signatureVersion = options.signatureVersion;
+      }
+
+      getS3 = function() {
+        return new aws.S3(s3Options);
+      };
     }
+
     if (options.uniquePrefix === undefined) {
         options.uniquePrefix = true;
     }
@@ -45,7 +53,7 @@ function S3Router(options, middleware) {
             Bucket: S3_BUCKET,
             Key: checkTrailingSlash(getFileKeyDir(req)) + req.params[0]
         };
-        var s3 = new aws.S3(s3Options);
+        var s3 = getS3();
         s3.getSignedUrl('getObject', params, function(err, url) {
             res.redirect(url);
         });
@@ -78,7 +86,7 @@ function S3Router(options, middleware) {
           res.set(options.headers);
         }
 
-        var s3 = new aws.S3(s3Options);
+        var s3 = getS3();
         var params = {
             Bucket: S3_BUCKET,
             Key: fileKey,


### PR DESCRIPTION
This resolves #46 using what was option 3 in my last comment. I added a new parameter called getS3 which accepts a function that returns a new S3 Service Object. This leaves existing behavior of when the S3 Service Object is initialized the same while still allowing custom configuration of S3.