### PR TITLE
Construct public URL for uploads

### DIFF
--- a/s3router.js
+++ b/s3router.js
@@ -99,12 +99,18 @@ function S3Router(options, middleware) {
                 console.log(err);
                 return res.send(500, "Cannot create S3 signed URL");
             }
-            res.json({
+            var json = {
                 signedUrl: data,
                 publicUrl: '/s3/uploads/' + filename,
                 filename: filename,
                 fileKey: fileKey,
-            });
+            };
+            if (typeof options.getWebsiteUrl === 'function') {
+                json.websiteUrl = options.getWebsiteUrl(fileKey);
+            } else if (options.getWebsiteUrl === true && options.region) {
+                json.websiteUrl = 'http://' + S3_BUCKET + '.s3-website.' + options.region + '.amazonaws.com/' + fileKey;
+            }
+            res.json(json);
         });
     });
 

--- a/s3router.js
+++ b/s3router.js
@@ -78,7 +78,7 @@ function S3Router(options, middleware) {
      * give temporary access to PUT an object in an S3 bucket.
      */
     router.get('/sign', middleware, function(req, res) {
-        var filename = (options.uniquePrefix ? uuidv4() + "_" : "") + req.query.objectName;
+        var filename = options.uniqueFilename ? uuidv4() : ((options.uniquePrefix ? uuidv4() + "_" : "") + req.query.objectName);
         var mimeType = req.query.contentType;
         var fileKey = checkTrailingSlash(getFileKeyDir(req)) + filename;
         // Set any custom headers


### PR DESCRIPTION
In case uploaded file becomes public-readable (due to bucket or object permissions or in case there is CDN distribution configured), it might be convenient to send object's public URL to the client to avoid going through temporary redirects in s3router.

Also add an option to construct object keys based solely on UUID and don't append original filename.