### PR TITLE
Added a `inputRef` prop allowing to set `ref` on the actual input

### DIFF
--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -30,7 +30,8 @@ var ReactS3Uploader = createReactClass({
         contentDisposition: PropTypes.string,
         server: PropTypes.string,
         scrubFilename: PropTypes.func,
-        s3path: PropTypes.string
+        s3path: PropTypes.string,
+        inputRef: PropTypes.func
     },
 
     getDefaultProps: function() {
@@ -53,7 +54,8 @@ var ReactS3Uploader = createReactClass({
             scrubFilename: function(filename) {
                 return filename.replace(/[^\w\d_\-\.]+/ig, '');
             },
-            s3path: ''
+            s3path: '',
+            inputRef: function(el){}
         };
     },
 
@@ -74,7 +76,7 @@ var ReactS3Uploader = createReactClass({
             contentDisposition: this.props.contentDisposition,
             server: this.props.server,
             scrubFilename: this.props.scrubFilename,
-            s3path: this.props.s3path
+            s3path: this.props.s3path,
         });
     },
 
@@ -91,15 +93,22 @@ var ReactS3Uploader = createReactClass({
     },
 
     getInputProps: function() {
-        var temporaryProps = objectAssign({}, this.props, {type: 'file', onChange: this.uploadFile});
+        // declare ref beforehand and filter out
+        // `inputRef` by `ReactS3Uploader.propTypes`
+        var additional = {
+          type: 'file',
+          onChange: this.uploadFile,
+          ref: this.props.innerRef
+        }
+        var temporaryProps = objectAssign({}, this.props, additional);
         var inputProps = {};
 
         var invalidProps = Object.keys(ReactS3Uploader.propTypes);
 
         for(var key in temporaryProps) {
-            if(temporaryProps.hasOwnProperty(key) && invalidProps.indexOf(key) === -1) {
-                inputProps[key] = temporaryProps[key];
-            }
+          if(temporaryProps.hasOwnProperty(key) && invalidProps.indexOf(key) === -1) {
+            inputProps[key] = temporaryProps[key];
+          }
         }
 
         return inputProps;

--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -98,8 +98,8 @@ var ReactS3Uploader = createReactClass({
         var additional = {
           type: 'file',
           onChange: this.uploadFile,
-          ref: this.props.innerRef
-        }
+          ref: this.props.inputRef
+        };
         var temporaryProps = objectAssign({}, this.props, additional);
         var inputProps = {};
 

--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -54,8 +54,7 @@ var ReactS3Uploader = createReactClass({
             scrubFilename: function(filename) {
                 return filename.replace(/[^\w\d_\-\.]+/ig, '');
             },
-            s3path: '',
-            inputRef: function(el){}
+            s3path: ''
         };
     },
 
@@ -76,7 +75,7 @@ var ReactS3Uploader = createReactClass({
             contentDisposition: this.props.contentDisposition,
             server: this.props.server,
             scrubFilename: this.props.scrubFilename,
-            s3path: this.props.s3path,
+            s3path: this.props.s3path
         });
     },
 
@@ -96,9 +95,9 @@ var ReactS3Uploader = createReactClass({
         // declare ref beforehand and filter out
         // `inputRef` by `ReactS3Uploader.propTypes`
         var additional = {
-          type: 'file',
-          onChange: this.uploadFile,
-          ref: this.props.inputRef
+            type: 'file',
+            onChange: this.uploadFile,
+            ref: this.props.inputRef
         };
         var temporaryProps = objectAssign({}, this.props, additional);
         var inputProps = {};
@@ -106,9 +105,9 @@ var ReactS3Uploader = createReactClass({
         var invalidProps = Object.keys(ReactS3Uploader.propTypes);
 
         for(var key in temporaryProps) {
-          if(temporaryProps.hasOwnProperty(key) && invalidProps.indexOf(key) === -1) {
-            inputProps[key] = temporaryProps[key];
-          }
+            if(temporaryProps.hasOwnProperty(key) && invalidProps.indexOf(key) === -1) {
+                inputProps[key] = temporaryProps[key];
+            }
         }
 
         return inputProps;


### PR DESCRIPTION
Addressing #123 and my personal pain when it comes to simplicity 😆 . While a more straightforward approach would be to simply pass in a `className` and then use `ReactDOM` to get the element with the appropriate selector, the enhancement allows the following:
```javascript
render = () => (
    <ReactS3Uploader
        inputRef={(el) => this.input = el}
        {...otherProps} 
    />
)
```

This is especially convenient, when you're trying to support a streamlined look across all browsers like so:
```
const Container = styled.div`
    &> input[type=file] {
        visibility: hidden;
        width: 0;
    }   
`
//.... in your component:
triggerFilePicker = () => this.input.click()
render = () => (
    <SomeSweetButton onClick={this.triggerFilePicker} />
    <ReactS3Uplaoder
        inputRef={(el) => this.input = el}
       {...otherProps}
    />
)
```