### PR TITLE
Move uniquePrefix to be AFTER the s3path

### DIFF
--- a/s3router.js
+++ b/s3router.js
@@ -78,7 +78,7 @@ function S3Router(options, middleware) {
      * give temporary access to PUT an object in an S3 bucket.
      */
     router.get('/sign', middleware, function(req, res) {
-        var filename = (options.uniquePrefix ? uuidv4() + "_" : "") + req.query.objectName;
+        var filename = req.query.path + (options.uniquePrefix ? uuidv4() + "_" : "") + req.query.objectName;
         var mimeType = req.query.contentType;
         var fileKey = checkTrailingSlash(getFileKeyDir(req)) + filename;
         // Set any custom headers

--- a/s3upload.js
+++ b/s3upload.js
@@ -78,7 +78,7 @@ S3Upload.prototype.createCORSRequest = function(method, url, opts) {
 
 S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
     var fileName = this.scrubFilename(file.name);
-    var queryString = '?objectName=' + this.s3path + fileName + '&contentType=' + encodeURIComponent(file.type);
+    var queryString = '?objectName=' + fileName + '&contentType=' + encodeURIComponent(file.type) + '&path=' + this.s3path;
     if (this.signingUrlQueryParams) {
         var signingUrlQueryParams = typeof this.signingUrlQueryParams === 'function' ? this.signingUrlQueryParams() : this.signingUrlQueryParams;
         Object.keys(signingUrlQueryParams).forEach(function(key) {


### PR DESCRIPTION
This allows a user to specify the folder a file will be uploaded to, while the file itself can be prefixed with a unique identifier.