### PR TITLE
Add onSignedUrl() handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ var ReactS3Uploader = require('react-s3-uploader');
     accept="image/*"
     s3path="/uploads/"
     preprocess={this.onUploadStart}
+    onSignedUrl={this.onSignedUrl}
     onProgress={this.onUploadProgress}
     onError={this.onUploadError}
     onFinish={this.onUploadFinish}

--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -13,6 +13,7 @@ var ReactS3Uploader = createReactClass({
         signingUrl: PropTypes.string,
         getSignedUrl: PropTypes.func,
         preprocess: PropTypes.func,
+        onSignedUrl: PropTypes.func,
         onProgress: PropTypes.func,
         onFinish: PropTypes.func,
         onError: PropTypes.func,
@@ -41,6 +42,9 @@ var ReactS3Uploader = createReactClass({
                 console.log('Pre-process: ' + file.name);
                 next(file);
             },
+            onSignedUrl: function( signingServerResponse ) {
+                console.log('Signing server response', signingServerResponse);
+            },
             onProgress: function(percent, message) {
                 console.log('Upload progress: ' + percent + '% ' + message);
             },
@@ -66,6 +70,7 @@ var ReactS3Uploader = createReactClass({
             signingUrl: this.props.signingUrl,
             getSignedUrl: this.props.getSignedUrl,
             preprocess: this.props.preprocess,
+            onSignedUrl: this.props.onSignedUrl,
             onProgress: this.props.onProgress,
             onFinishS3Put: this.props.onFinish,
             onError: this.props.onError,

--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -43,7 +43,7 @@ var ReactS3Uploader = createReactClass({
                 next(file);
             },
             onSignedUrl: function( signingServerResponse ) {
-                console.log('Signing server response', signingServerResponse);
+                console.log('Signing server response: ', signingServerResponse);
             },
             onProgress: function(percent, message) {
                 console.log('Upload progress: ' + percent + '% ' + message);

--- a/s3upload.js
+++ b/s3upload.js
@@ -104,6 +104,7 @@ S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
             var result;
             try {
                 result = JSON.parse(xhr.responseText);
+                this.onSignedUrl( result );
             } catch (error) {
                 this.onError('Invalid response from server', file);
                 return false;


### PR DESCRIPTION
I have a situation where I need to handle the data returned from the signingUrl server as soon as it's available. The simplest solution I could see was to expose an onSignedUrl handler that passes back that info before uploading. I tried to make it conform to the style of all the others, so it would be a simple addition to the lifecycle handlers.