### PR TITLE
Enable 201 response from cloud provider

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -6,7 +6,7 @@
 S3Upload.prototype.server = '';
 S3Upload.prototype.signingUrl = '/sign-s3';
 S3Upload.prototype.signingUrlMethod = 'GET';
-S3Upload.prototype.signingUrlSuccessResponses = [200, 201];
+S3Upload.prototype.successResponses = [200, 201];
 S3Upload.prototype.fileElement = null;
 S3Upload.prototype.files = null;
 
@@ -102,7 +102,7 @@ S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
     }
     xhr.overrideMimeType && xhr.overrideMimeType('text/plain; charset=x-user-defined');
     xhr.onreadystatechange = function() {
-        if (xhr.readyState === 4 && this.signingUrlSuccessResponses.indexOf(xhr.status) >= 0) {
+        if (xhr.readyState === 4 && this.successResponses.indexOf(xhr.status) >= 0) {
             var result;
             try {
                 result = JSON.parse(xhr.responseText);
@@ -112,7 +112,7 @@ S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
                 return false;
             }
             return callback(result);
-        } else if (xhr.readyState === 4 && this.signingUrlSuccessResponses.indexOf(xhr.status) < 0) {
+        } else if (xhr.readyState === 4 && this.successResponses.indexOf(xhr.status) < 0) {
             return this.onError('Could not contact request signing server. Status = ' + xhr.status, file);
         }
     }.bind(this);
@@ -125,7 +125,7 @@ S3Upload.prototype.uploadToS3 = function(file, signResult) {
         this.onError('CORS not supported', file);
     } else {
         xhr.onload = function() {
-            if (xhr.status === 200) {
+            if (this.successResponses.indexOf(xhr.status) >= 0) {
                 this.onProgress(100, 'Upload completed', file);
                 return this.onFinishS3Put(signResult, file);
             } else {


### PR DESCRIPTION
I was testing whether react-s3-uploader works as is when using an Azure storage container backend - and it turns out it does except for the explicit 200 check from the cloud service (aws returns 200 from the PUT, while Azure returns 201).

That is, as long as your backend signing function can provide Azure pre-signed urls (which is quite similar to azure) then this frontend component will just work with this change.

I've not added any comments about the fact that it works with Azure in the change (as you may not want to support that).

Thanks