### PR TITLE
Pass req object to getS3 call

### DIFF
--- a/s3router.js
+++ b/s3router.js
@@ -53,7 +53,7 @@ function S3Router(options, middleware) {
             Bucket: S3_BUCKET,
             Key: checkTrailingSlash(getFileKeyDir(req)) + req.params[0]
         };
-        var s3 = getS3();
+        var s3 = getS3(req);
         s3.getSignedUrl('getObject', params, function(err, url) {
             res.redirect(url);
         });
@@ -86,7 +86,7 @@ function S3Router(options, middleware) {
           res.set(options.headers);
         }
 
-        var s3 = getS3();
+        var s3 = getS3(req);
         var params = {
             Bucket: S3_BUCKET,
             Key: fileKey,


### PR DESCRIPTION
Pass in `req` to getS3 function so that request details can be used to determine the proper AWS keys. I needed to change what AWS keys I use on a per-user basis so the `req` object is needed to get the current user.