### PR TITLE
inputRef should support React.createRef #176

### DIFF
--- a/ReactS3Uploader.js
+++ b/ReactS3Uploader.js
@@ -32,7 +32,10 @@ var ReactS3Uploader = createReactClass({
         server: PropTypes.string,
         scrubFilename: PropTypes.func,
         s3path: PropTypes.string,
-        inputRef: PropTypes.func,
+        inputRef: PropTypes.oneOfType([
+          PropTypes.object,
+          PropTypes.func
+        ]),
         autoUpload: PropTypes.bool
     },
 


### PR DESCRIPTION
For cases when custom components reference ReactS3Uploader's `input` through a `React.createRef()`, for example:

```javascript
  const uploaderInputRef = React.createRef();
  ...
      <ReactS3Uploader
        ...
        inputRef={uploaderInputRef}
      />
      <button onClick={() => { uploaderInputRef.current.click(); }}>upload file</button>



```