### PR TITLE
Find file mime type

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "aws-sdk": "2.x",
     "create-react-class": "^15.5.2",
+    "mime-types": "^2.1.24",
     "object-assign": "^2.0.0",
     "prop-types": "^15.5.8",
     "uuid": "^3.1.0"

--- a/s3upload.js
+++ b/s3upload.js
@@ -49,11 +49,7 @@ function S3Upload(options) {
 }
 
 function getFileMimeType(file) {
-    if (file.type) {
-        return file.type;
-    } else {
-        return mime.lookup(file.name);
-    }
+    return mime.lookup(file.name);
 }
 
 S3Upload.prototype.handleFileSelect = function(files) {


### PR DESCRIPTION
### Problem with mime type.

The package is using mime-type from file.type variable. But Windows machines browsers don't have it for .csv format ([source](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/ms775147(v=vs.85))).
Therefore, Content-Type for a PUT request was empty if I choose .csv files on windows. And it was throwing the error: XHR error (net::ERR_CONNECTION_RESET).

I added [mime-types](https://www.npmjs.com/package/mime-types) package and a few changes.

