### PR TITLE
Add option to change when the signed upload URL expires

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ app.use('/s3', require('react-s3-uploader/s3router')({
     bucket: "MyS3Bucket",
     region: 'us-east-1', //optional
     signatureVersion: 'v4', //optional (use for some amazon regions: frankfurt and others)
+    signatureExpires: 60, //optional, number of seconds the upload signed URL should be valid for (defaults to 60)
     headers: {'Access-Control-Allow-Origin': '*'}, // optional
     ACL: 'private', // this is default
     uniquePrefix: true // (4.0.2 and above) default is true, setting the attribute to false preserves the original filename in S3

--- a/s3router.js
+++ b/s3router.js
@@ -90,7 +90,7 @@ function S3Router(options, middleware) {
         var params = {
             Bucket: S3_BUCKET,
             Key: fileKey,
-            Expires: 60,
+            Expires: options.signatureExpires || 60,
             ContentType: mimeType,
             ACL: options.ACL || 'private'
         };


### PR DESCRIPTION
Add an option to provide a custom value for the `Expires` parameter passed to `getSignedUrl`. 

In my use case, when multiple large files are uploaded at once it can take more than 60 seconds for the PUT request to actually happen causing it to come back with a 403. This problem can also happen if the signing server responds slowly because all of the signing server requests happen first making the upload PUT requests wait. Since I do not know how others use this, I did not change the default and instead added an option to change `Expires` to whatever makes sense for your application. 