### PR TITLE
When MIME type cannot be determined, set sensible default

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -175,7 +175,7 @@ S3Upload.prototype.uploadToS3 = function(file, signResult) {
         }.bind(this);
     }
 
-    var fileType = getFileMimeType(file);
+    var fileType = getFileMimeType(file) || 'application/octet-stream';
     var headers = {
       'content-type': fileType
     };


### PR DESCRIPTION
It is possible for `getFileMimeType` to return `false` if it is unable to determine the file type.  When that happens, an error occurs in React S3 Uploader: `Uncaught TypeError: fileType.substr is not a function`.

To resolve this issue, [the mime-types package](https://github.com/jshttp/mime-types) recommends that a default be set:

>  Instead of naively returning the first available type, `mime-types` simply returns `false`, so do `var type = mime.lookup('unrecognized') || 'application/octet-stream'`.