### PR TITLE
fix: :bug: Do not set default x-amz-acl header if query param exists

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -179,6 +179,12 @@ S3Upload.prototype.uploadToS3 = function(file, signResult) {
     var headers = {
       'content-type': fileType
     };
+    var urlQueryParams = {};
+    var regexp = new RegExp('(\\?|\\&)([^=]+)\\=([^&]+)', 'g');
+    var queryPair;
+    while ((queryPair = regexp.exec(signResult.signedUrl)) !== null) {
+        urlQueryParams[queryPair[2]] = queryPair[3];
+    }
 
     if (this.contentDisposition) {
         var disposition = this.contentDisposition;
@@ -193,8 +199,8 @@ S3Upload.prototype.uploadToS3 = function(file, signResult) {
         var fileName = this.scrubFilename(file.name)
         headers['content-disposition'] = disposition + '; filename="' + fileName + '"';
     }
-    if (!this.uploadRequestHeaders) {
-        xhr.setRequestHeader('x-amz-acl', 'public-read');
+    if (!this.uploadRequestHeaders && !urlQueryParams.hasOwnProperty('x-amz-acl')) {
+        xhr.setRequestHeader('x-amz-acl', 'private');
     }
     [signResult.headers, this.uploadRequestHeaders].filter(Boolean).forEach(function (hdrs) {
         Object.entries(hdrs).forEach(function(pair) {


### PR DESCRIPTION
This fixes an issue with my use case.  I'm generating a signed URL server-side that includes the ACL setting on it as a query param.  This library adds a default header to the request that conflicts with the acl setting in the query params.  This used to work okay.  But S3 changed recently such that it returns an error when you have conflicting ACL settings in the URL and the headers.

This change makes it check the query params for an ACL setting before adding the default header.

I tried to keep compatibility in mind, as the rest of the code seems to be written from a legacy browser friendly position.

In the meantime, I'm working around this by setting `uploadRequestHeaders` to an empty object in my project's code.