### PR TITLE
Refine signedUrl response type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,22 +3,20 @@ declare module 'react-s3-uploader' {
 
   export interface S3Response {
     signedUrl: string;
-    publicUrl: string;
-    filename: string;
-    fileKey: string;
+    headers?: Record<string, string> | null;
   }
 
-  export interface ReactS3UploaderProps {
+  export interface ReactS3UploaderProps<R extends S3Response = S3Response> {
     signingUrl?: string;
     signingUrlMethod?: 'GET' | 'POST';
-    getSignedUrl?: (file: File, callback: (params: S3Response) => void) => void;
+    getSignedUrl?: (file: File, callback: (params: R) => void) => void;
     accept?: string;
     s3path?: string;
     preprocess?: (file: File, next: (file: File) => void) => void;
-    onSignedUrl?: (response: S3Response) => void;
+    onSignedUrl?: (response: R) => void;
     onProgress?: (percent: number, status: string, file: File) => void;
     onError?: (message: string) => void;
-    onFinish?: (result: S3Response, file: File) => void;
+    onFinish?: (result: R, file: File) => void;
     signingUrlHeaders?: {
       additional: object;
     };
@@ -35,7 +33,7 @@ declare module 'react-s3-uploader' {
     [key: string]: any;
   }
 
-  class ReactS3Uploader extends Component<ReactS3UploaderProps, unknown> { }
+  class ReactS3Uploader<R extends S3Response = S3Response> extends Component<ReactS3UploaderProps<R>, unknown> { }
 
   export default ReactS3Uploader;
 }
@@ -43,8 +41,8 @@ declare module 'react-s3-uploader' {
 declare module 'react-s3-uploader/s3upload' {
   import { ReactS3UploaderProps, S3Response } from 'react-s3-uploader';
 
-  export interface S3UploadOptions extends Pick<
-    ReactS3UploaderProps,
+  export interface S3UploadOptions<R extends S3Response = S3Response> extends Pick<
+    ReactS3UploaderProps<R>,
     | 'contentDisposition'
     | 'getSignedUrl'
     | 'onProgress'
@@ -61,16 +59,16 @@ declare module 'react-s3-uploader/s3upload' {
     | 'uploadRequestHeaders'> {
     fileElement?: HTMLInputElement | null;
     files?: HTMLInputElement['files'] | null;
-    onFinishS3Put?: ReactS3UploaderProps['onFinish'];
+    onFinishS3Put?: ReactS3UploaderProps<R>['onFinish'];
     successResponses?: number[];
     scrubFilename?: (filename: string) => string;
   }
 
-  class S3Upload {
-    constructor(options: ReactS3UploaderProps);
+  class S3Upload<R extends S3Response = S3Response> {
+    constructor(options: ReactS3UploaderProps<R>);
     abortUpload(): void;
-    uploadFile(file: File): Promise<S3Response>;
-    uploadToS3(file: File, signResult: S3Response): void;
+    uploadFile(file: File): Promise<R>;
+    uploadToS3(file: File, signResult: R): void;
   }
 
   export default S3Upload;


### PR DESCRIPTION
The implementation only requires `signedUrl` to be present, and supports `headers` if provided.  Otherwise it passes through the S3 response you provide based on how your server or `getSignedUrl` implementation works.

This change tries to better capture this.

It was a bit strange that the other fields like `publicUrl`, `filename`, and `fileKey` were included before when they were not used in any way by the library.